### PR TITLE
Fixed Cloud Deploy error during deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,18 +203,21 @@ gcloud deploy apply \
  gcloud container hub memberships register $GKE_TEST \
  --gke-uri=https://container.googleapis.com/v1/projects/${PROJECT_GKE}/locations/$REGION/clusters/$GKE_TEST \
  --enable-workload-identity \
+ --install-connect-agent \
  --project $PROJECT_CICD
 
 # register stage cluster to fleet
  gcloud container hub memberships register $GKE_STAGE \
  --gke-uri=https://container.googleapis.com/v1/projects/${PROJECT_GKE}/locations/$REGION/clusters/$GKE_STAGE \
  --enable-workload-identity \
+ --install-connect-agent \
  --project $PROJECT_CICD
 
 # register prod cluster to fleet
  gcloud container hub memberships register $GKE_PROD \
  --gke-uri=https://container.googleapis.com/v1/projects/${PROJECT_GKE}/locations/$REGION/clusters/$GKE_PROD \
  --enable-workload-identity \
+ --install-connect-agent \
  --project $PROJECT_CICD
 
 # get context for test cluster

--- a/terraform/5_deploy-pipeline/main.tf
+++ b/terraform/5_deploy-pipeline/main.tf
@@ -151,7 +151,8 @@ resource "null_resource" "register_gke_hub_test" {
       gcloud container hub memberships register ${var.gke_test_name} \
         --project ${var.project_cicd} \
         --gke-uri=https://container.googleapis.com/v1/projects/${var.project_gke}/locations/${var.region}/clusters/${var.gke_test_name} \
-        --enable-workload-identity 
+        --enable-workload-identity
+        --install-connect-agent
     EOT
   }
 }
@@ -163,7 +164,8 @@ resource "null_resource" "register_gke_hub_stage" {
       gcloud container hub memberships register ${var.gke_stage_name} \
         --project ${var.project_cicd} \
         --gke-uri=https://container.googleapis.com/v1/projects/${var.project_gke}/locations/${var.region}/clusters/${var.gke_stage_name} \
-        --enable-workload-identity 
+        --enable-workload-identity
+        --install-connect-agent
     EOT
   }
 }
@@ -175,7 +177,8 @@ resource "null_resource" "register_gke_hub_prod" {
       gcloud container hub memberships register ${var.gke_prod_name} \
         --project ${var.project_cicd} \
         --gke-uri=https://container.googleapis.com/v1/projects/${var.project_gke}/locations/${var.region}/clusters/${var.gke_prod_name} \
-        --enable-workload-identity 
+        --enable-workload-identity
+        --install-connect-agent
     EOT
   }
 }


### PR DESCRIPTION
--install-connect-agent flag is required to install the Connect Agent when executing gcloud container fleet memberships register command

Reference: https://cloud.google.com/deploy/docs/anthos-targets